### PR TITLE
adjust normal text color in the Docs Outline widget

### DIFF
--- a/google-drive-dark-stylish.css
+++ b/google-drive-dark-stylish.css
@@ -260,7 +260,9 @@
   }
 
   .kix-page span,
-  .kix-wordhtmlgenerator-word-node {
+  .kix-wordhtmlgenerator-word-node,
+  .navigation-widget,
+  .navigation-item-content {
     /*[normal_text_color]*/
     color: #DDDDDD !important;
   }


### PR DESCRIPTION
If you open an Outline in Docs (Tools -> Document outline) the text is unreadable (black on black).
This change applies the color #DDDDDD to the navigation widget, making it usable.