### PR TITLE
Fix docs editor background color

### DIFF
--- a/userstyles.user.css
+++ b/userstyles.user.css
@@ -312,7 +312,7 @@
     border-bottom: none !important;
   }
 
-  .kix-ruler-background-inner {
+  .kix-ruler-background-inner, .kix-appview-editor {
     background: #444 !important;
   }
 


### PR DESCRIPTION
The css class to set the background color on should be `.kix-appview-editor` now.

Solves https://github.com/YodaEmbedding/Stylish-Google-Drive-Dark/issues/13